### PR TITLE
Add mockServerVersion option. Update to MockServer version 5.4.1

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -67,7 +67,8 @@ module.exports = function (grunt) {
         var done = this.async();
         var artifactoryHost = 'oss.sonatype.org';
         var artifactoryPath = '/content/repositories/releases/org/mock-server/mockserver-netty/';
-        require('./downloadJar').downloadJar('5.3.0', artifactoryHost, artifactoryPath).then(function () {
+        var mockServerVersion = '5.4.1';
+        require('./downloadJar').downloadJar(mockServerVersion, artifactoryHost, artifactoryPath).then(function () {
             done(true);
         }, function () {
             done(false);

--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ Default value: `/content/repositories/releases/org/mock-server/mockserver-netty/
 
 This value specifies the path to the artifactory leading to the mockserver-netty jar with dependencies.
 
+#### options.mockServerVersion
+Type: `String` 
+Default value: `5.4.1`
+
+This value specifies the artifact version of MockServer to download.
+
 #### options.verbose
 Type: `Boolean`
 Default value: `false`

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ module.exports = (function () {
     var mockServer;
     var artifactoryHost = 'oss.sonatype.org';
     var artifactoryPath = '/content/repositories/releases/org/mock-server/mockserver-netty/';
+    var mockServerVersion = '5.4.1';
 
     var Q = require('q');
     var http = require('http');
@@ -144,10 +145,14 @@ module.exports = (function () {
                 artifactoryPath = options.artifactoryPath;
             }
 
+            if (options.mockServerVersion) {
+                mockServerVersion = options.mockServerVersion;
+            }
+
             var startupRetries = 100; // wait for 10 seconds
 
             // double check the jar has already been downloaded
-            require('./downloadJar').downloadJar('5.3.0', artifactoryHost, artifactoryPath).then(function () {
+            require('./downloadJar').downloadJar(mockServerVersion, artifactoryHost, artifactoryPath).then(function () {
 
                 var spawn = require('child_process').spawn;
                 var glob = require('glob');


### PR DESCRIPTION

Update to last version and allow to override manually the version using a new option.
This will help to avoid waiting for new releases and maybe to fix the version when updating the dependencies.