### PR TITLE
Added an option to set the number of retries on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,13 @@ start_mockserver: {
 }
 ```  
 
+#### options.startupRetries
+Type: `Integer`
+Default value if javaDebugPort is not set: `110`
+Default value if javaDebugPort is set: `500`
+
+This value indicates the how many times we will call the check to confirm if the mock server started up correctly. It will default to 110 which will take about 11 seconds to complete, this is normally long enough for the server to startup. The server can take longer to start up if Java debugging is enabled so this will default to 500. The default will, in some cases, need to be overridden as the JVM may take longer to start up on some architectures,  e.g. Mac seems to take a little longer.
+
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).
 

--- a/index.js
+++ b/index.js
@@ -144,7 +144,7 @@ module.exports = (function () {
                 artifactoryPath = options.artifactoryPath;
             }
 
-            var startupRetries = 100; // wait for 10 seconds
+            var startupRetries = options.startupRetries || options.javaDebugPort ? 500 : 110;
 
             // double check the jar has already been downloaded
             require('./downloadJar').downloadJar('5.5.1', artifactoryHost, artifactoryPath).then(function () {
@@ -161,7 +161,6 @@ module.exports = (function () {
                 }
                 if (options.javaDebugPort) {
                     commandLineOptions.push('-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=' + options.javaDebugPort);
-                    startupRetries = 500;
                 }
                 if (options.jvmOptions) {
                     commandLineOptions.push(options.jvmOptions);


### PR DESCRIPTION
There you go. I couldn't see any tests for the options. I figured you mustn't be testing the options to avoid having to test configuration and I didn't want clutter up the test suite if that was that case. That being said if you feel this needs a test you only need let me now where you think they'd be best placed in the project and I can go ahead and do that for you.