### PR TITLE
Use the follow-redirects package to download the mockserver binary

### DIFF
--- a/downloadJar.js
+++ b/downloadJar.js
@@ -12,7 +12,7 @@
     function downloadJar(version, artifactoryHost, artifactoryPath) {
         var Q = require('q');
         var deferred = Q.defer();
-        var https = require('https');
+        var https = require('follow-redirects').https;
         var fs = require('fs');
         var glob = require('glob');
         var dest = 'mockserver-netty-' + version + '-jar-with-dependencies.jar';

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,14 +14,14 @@
             }
         },
         "@babel/generator": {
-            "version": "7.3.0",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.0.tgz",
-            "integrity": "sha512-dZTwMvTgWfhmibq4V9X+LMf6Bgl7zAodRn9PvcPdhlzFMbvUutx74dbEv7Atz3ToeEpevYEJtAwfxq/bDCzHWg==",
+            "version": "7.3.4",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.4.tgz",
+            "integrity": "sha512-8EXhHRFqlVVWXPezBW5keTiQi/rJMQTg/Y9uVCEZ0CAF3PKtCCaVRnp64Ii1ujhkoDhhF1fVsImoN4yJ2uz4Wg==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.3.0",
+                "@babel/types": "^7.3.4",
                 "jsesc": "^2.5.1",
-                "lodash": "^4.17.10",
+                "lodash": "^4.17.11",
                 "source-map": "^0.5.0",
                 "trim-right": "^1.0.1"
             }
@@ -67,9 +67,9 @@
             }
         },
         "@babel/parser": {
-            "version": "7.3.1",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.1.tgz",
-            "integrity": "sha512-ATz6yX/L8LEnC3dtLQnIx4ydcPxhLcoy9Vl6re00zb2w5lG6itY6Vhnr1KFRPq/FHNsgl/gh2mjNN20f9iJTTA==",
+            "version": "7.3.4",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.4.tgz",
+            "integrity": "sha512-tXZCqWtlOOP4wgCp6RjRvLmfuhnqTLy9VHwRochJBCP2nDm27JnnuFEnXFASVyQNHk36jD1tAammsCEEqgscIQ==",
             "dev": true
         },
         "@babel/template": {
@@ -84,30 +84,41 @@
             }
         },
         "@babel/traverse": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.2.3.tgz",
-            "integrity": "sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==",
+            "version": "7.3.4",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.3.4.tgz",
+            "integrity": "sha512-TvTHKp6471OYEcE/91uWmhR6PrrYywQntCHSaZ8CM8Vmp+pjAusal4nGB2WCCQd0rvI7nOMKn9GnbcvTUz3/ZQ==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
-                "@babel/generator": "^7.2.2",
+                "@babel/generator": "^7.3.4",
                 "@babel/helper-function-name": "^7.1.0",
                 "@babel/helper-split-export-declaration": "^7.0.0",
-                "@babel/parser": "^7.2.3",
-                "@babel/types": "^7.2.2",
+                "@babel/parser": "^7.3.4",
+                "@babel/types": "^7.3.4",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0",
-                "lodash": "^4.17.10"
+                "lodash": "^4.17.11"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                }
             }
         },
         "@babel/types": {
-            "version": "7.3.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.0.tgz",
-            "integrity": "sha512-QkFPw68QqWU1/RVPyBe8SO7lXbPfjtqAxRYQKpFpaB8yMq7X2qAqfwK5LKoQufEkSmO5NQ70O6Kc3Afk03RwXw==",
+            "version": "7.3.4",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.4.tgz",
+            "integrity": "sha512-WEkp8MsLftM7O/ty580wAmZzN1nDmCACc5+jFzUt+GUFNNIi3LdRlueYz0YIlmJhlZx1QYDMZL5vdWCL0fNjFQ==",
             "dev": true,
             "requires": {
                 "esutils": "^2.0.2",
-                "lodash": "^4.17.10",
+                "lodash": "^4.17.11",
                 "to-fast-properties": "^2.0.0"
             }
         },
@@ -118,9 +129,9 @@
             "dev": true
         },
         "ajv": {
-            "version": "6.7.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.7.0.tgz",
-            "integrity": "sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==",
+            "version": "6.10.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+            "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
             "dev": true,
             "requires": {
                 "fast-deep-equal": "^2.0.1",
@@ -258,12 +269,6 @@
             "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
             "dev": true
         },
-        "builtin-modules": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-            "dev": true
-        },
         "camelcase": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
@@ -382,9 +387,9 @@
             "dev": true
         },
         "coveralls": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.2.tgz",
-            "integrity": "sha512-Tv0LKe/MkBOilH2v7WBiTBdudg2ChfGbdXafc/s330djpF3zKOmuehTeRwjXWc7pzfj9FrDUTA7tEx6Div8NFw==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.3.tgz",
+            "integrity": "sha512-viNfeGlda2zJr8Gj1zqXpDMRjw9uM54p7wzZdvLRyOgnAfCe974Dq4veZkjJdxQXbmdppu6flEajFYseHYaUhg==",
             "dev": true,
             "requires": {
                 "growl": "~> 1.10.0",
@@ -392,7 +397,7 @@
                 "lcov-parse": "^0.0.10",
                 "log-driver": "^1.2.7",
                 "minimist": "^1.2.0",
-                "request": "^2.85.0"
+                "request": "^2.86.0"
             },
             "dependencies": {
                 "esprima": {
@@ -402,9 +407,9 @@
                     "dev": true
                 },
                 "js-yaml": {
-                    "version": "3.12.1",
-                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
-                    "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+                    "version": "3.12.2",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
+                    "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
                     "dev": true,
                     "requires": {
                         "argparse": "^1.0.7",
@@ -458,10 +463,9 @@
             }
         },
         "debug": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-            "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-            "dev": true,
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+            "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
             "requires": {
                 "ms": "^2.1.1"
             }
@@ -485,21 +489,15 @@
             "dev": true
         },
         "dom-serializer": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-            "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+            "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
             "dev": true,
             "requires": {
-                "domelementtype": "~1.1.1",
-                "entities": "~1.1.1"
+                "domelementtype": "^1.3.0",
+                "entities": "^1.1.1"
             },
             "dependencies": {
-                "domelementtype": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-                    "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
-                    "dev": true
-                },
                 "entities": {
                     "version": "1.1.2",
                     "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
@@ -577,9 +575,9 @@
             "dev": true
         },
         "esm": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.0.tgz",
-            "integrity": "sha512-yK4IiHmmInOk9q4xbJXdUfPV0ju7GbRCbhtpe5/gH7nRiD6RAb12Ix7zfsqQkDL5WERwzFlq/eT6zTXDWwIk+w==",
+            "version": "3.2.18",
+            "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.18.tgz",
+            "integrity": "sha512-1UENjnnI37UDp7KuOqKYjfqdaMim06eBWnDv37smaxTIzDl0ZWnlgoXwsVwD9+Lidw+q/f1gUf2diVMDCycoVw==",
             "dev": true
         },
         "esprima": {
@@ -670,6 +668,14 @@
                 }
             }
         },
+        "follow-redirects": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
+            "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
+            "requires": {
+                "debug": "^3.2.6"
+            }
+        },
         "foreground-child": {
             "version": "1.5.6",
             "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
@@ -749,9 +755,9 @@
             }
         },
         "globals": {
-            "version": "11.10.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-11.10.0.tgz",
-            "integrity": "sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ==",
+            "version": "11.11.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
+            "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
             "dev": true
         },
         "graceful-fs": {
@@ -816,6 +822,12 @@
                         "nopt": "~3.0.6",
                         "resolve": "~1.1.0"
                     }
+                },
+                "resolve": {
+                    "version": "1.1.7",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+                    "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+                    "dev": true
                 }
             }
         },
@@ -830,12 +842,12 @@
             },
             "dependencies": {
                 "async": {
-                    "version": "2.6.1",
-                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-                    "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+                    "version": "2.6.2",
+                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+                    "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
                     "dev": true,
                     "requires": {
-                        "lodash": "^4.17.10"
+                        "lodash": "^4.17.11"
                     }
                 }
             }
@@ -1023,15 +1035,6 @@
             "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
             "dev": true
         },
-        "is-builtin-module": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-            "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-            "dev": true,
-            "requires": {
-                "builtin-modules": "^1.0.0"
-            }
-        },
         "is-finite": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
@@ -1072,15 +1075,15 @@
             "dev": true
         },
         "istanbul-lib-coverage": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
-            "integrity": "sha512-nPvSZsVlbG9aLhZYaC3Oi1gT/tpyo3Yt5fNyf6NmcKIayz4VV/txxJFFKAK/gU4dcNn8ehsanBbVHVl0+amOLA==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+            "integrity": "sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw==",
             "dev": true
         },
         "istanbul-lib-instrument": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.0.0.tgz",
-            "integrity": "sha512-eQY9vN9elYjdgN9Iv6NS/00bptm02EBBk70lRMaVjeA6QYocQgenVrSgC28TJurdnZa80AGO3ASdFN+w/njGiQ==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.1.0.tgz",
+            "integrity": "sha512-ooVllVGT38HIk8MxDj/OIHXSYvH+1tq/Vb38s8ixt9GoJadXska4WkGY+0wkmtYCZNYtaARniH/DixUGGLZ0uA==",
             "dev": true,
             "requires": {
                 "@babel/generator": "^7.0.0",
@@ -1088,7 +1091,7 @@
                 "@babel/template": "^7.0.0",
                 "@babel/traverse": "^7.0.0",
                 "@babel/types": "^7.0.0",
-                "istanbul-lib-coverage": "^2.0.1",
+                "istanbul-lib-coverage": "^2.0.3",
                 "semver": "^5.5.0"
             }
         },
@@ -1248,18 +1251,18 @@
             }
         },
         "mime-db": {
-            "version": "1.37.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-            "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
+            "version": "1.38.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
+            "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
             "dev": true
         },
         "mime-types": {
-            "version": "2.1.21",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
-            "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+            "version": "2.1.22",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
+            "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
             "dev": true,
             "requires": {
-                "mime-db": "~1.37.0"
+                "mime-db": "~1.38.0"
             }
         },
         "minimatch": {
@@ -1314,8 +1317,7 @@
         "ms": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-            "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-            "dev": true
+            "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         },
         "nodeunit": {
             "version": "0.11.3",
@@ -1337,13 +1339,13 @@
             }
         },
         "normalize-package-data": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.2.tgz",
-            "integrity": "sha512-YcMnjqeoUckXTPKZSAsPjUPLxH85XotbpqK3w4RyCwdFQSU5FxxBys8buehkSfg0j9fKvV1hn7O0+8reEgkAiw==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+            "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
             "dev": true,
             "requires": {
                 "hosted-git-info": "^2.1.4",
-                "is-builtin-module": "^1.0.0",
+                "resolve": "^1.10.0",
                 "semver": "2 || 3 || 4 || 5",
                 "validate-npm-package-license": "^3.0.1"
             }
@@ -1355,53 +1357,37 @@
             "dev": true
         },
         "nyc": {
-            "version": "13.1.0",
-            "resolved": "https://registry.npmjs.org/nyc/-/nyc-13.1.0.tgz",
-            "integrity": "sha512-3GyY6TpQ58z9Frpv4GMExE1SV2tAgYqC7HSy2omEhNiCT3mhT9NyiOvIE8zkbuJVFzmvvNTnE4h/7/wQae7xLg==",
+            "version": "13.3.0",
+            "resolved": "https://registry.npmjs.org/nyc/-/nyc-13.3.0.tgz",
+            "integrity": "sha512-P+FwIuro2aFG6B0Esd9ZDWUd51uZrAEoGutqZxzrVmYl3qSfkLgcQpBPBjtDFsUQLFY1dvTQJPOyeqr8S9GF8w==",
             "dev": true,
             "requires": {
                 "archy": "^1.0.0",
                 "arrify": "^1.0.1",
-                "caching-transform": "^2.0.0",
+                "caching-transform": "^3.0.1",
                 "convert-source-map": "^1.6.0",
-                "debug-log": "^1.0.1",
                 "find-cache-dir": "^2.0.0",
                 "find-up": "^3.0.0",
                 "foreground-child": "^1.5.6",
                 "glob": "^7.1.3",
-                "istanbul-lib-coverage": "^2.0.1",
-                "istanbul-lib-hook": "^2.0.1",
-                "istanbul-lib-instrument": "^3.0.0",
-                "istanbul-lib-report": "^2.0.2",
-                "istanbul-lib-source-maps": "^2.0.1",
-                "istanbul-reports": "^2.0.1",
+                "istanbul-lib-coverage": "^2.0.3",
+                "istanbul-lib-hook": "^2.0.3",
+                "istanbul-lib-instrument": "^3.1.0",
+                "istanbul-lib-report": "^2.0.4",
+                "istanbul-lib-source-maps": "^3.0.2",
+                "istanbul-reports": "^2.1.1",
                 "make-dir": "^1.3.0",
                 "merge-source-map": "^1.1.0",
                 "resolve-from": "^4.0.0",
-                "rimraf": "^2.6.2",
+                "rimraf": "^2.6.3",
                 "signal-exit": "^3.0.2",
                 "spawn-wrap": "^1.4.2",
-                "test-exclude": "^5.0.0",
+                "test-exclude": "^5.1.0",
                 "uuid": "^3.3.2",
-                "yargs": "11.1.0",
-                "yargs-parser": "^9.0.2"
+                "yargs": "^12.0.5",
+                "yargs-parser": "^11.1.1"
             },
             "dependencies": {
-                "align-text": {
-                    "version": "0.1.4",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^3.0.2",
-                        "longest": "^1.0.1",
-                        "repeat-string": "^1.5.2"
-                    }
-                },
-                "amdefine": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "dev": true
-                },
                 "ansi-regex": {
                     "version": "3.0.0",
                     "bundled": true,
@@ -1426,9 +1412,12 @@
                     "dev": true
                 },
                 "async": {
-                    "version": "1.5.2",
+                    "version": "2.6.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "lodash": "^4.17.11"
+                    }
                 },
                 "balanced-match": {
                     "version": "1.0.0",
@@ -1444,61 +1433,42 @@
                         "concat-map": "0.0.1"
                     }
                 },
-                "builtin-modules": {
-                    "version": "1.1.1",
-                    "bundled": true,
-                    "dev": true
-                },
                 "caching-transform": {
-                    "version": "2.0.0",
+                    "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "make-dir": "^1.0.0",
-                        "md5-hex": "^2.0.0",
-                        "package-hash": "^2.0.0",
-                        "write-file-atomic": "^2.0.0"
+                        "hasha": "^3.0.0",
+                        "make-dir": "^1.3.0",
+                        "package-hash": "^3.0.0",
+                        "write-file-atomic": "^2.3.0"
                     }
                 },
                 "camelcase": {
-                    "version": "1.2.1",
+                    "version": "5.0.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "center-align": {
-                    "version": "0.1.3",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "align-text": "^0.1.3",
-                        "lazy-cache": "^1.0.3"
-                    }
+                    "dev": true
                 },
                 "cliui": {
-                    "version": "2.1.0",
+                    "version": "4.1.0",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
-                        "center-align": "^0.1.1",
-                        "right-align": "^0.1.1",
-                        "wordwrap": "0.0.2"
-                    },
-                    "dependencies": {
-                        "wordwrap": {
-                            "version": "0.0.2",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        }
+                        "string-width": "^2.1.1",
+                        "strip-ansi": "^4.0.0",
+                        "wrap-ansi": "^2.0.0"
                     }
                 },
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
                     "dev": true
+                },
+                "commander": {
+                    "version": "2.17.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
                 },
                 "commondir": {
                     "version": "1.0.1",
@@ -1528,17 +1498,12 @@
                     }
                 },
                 "debug": {
-                    "version": "3.1.0",
+                    "version": "4.1.1",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ms": "2.0.0"
+                        "ms": "^2.1.1"
                     }
-                },
-                "debug-log": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "dev": true
                 },
                 "decamelize": {
                     "version": "1.2.0",
@@ -1551,6 +1516,14 @@
                     "dev": true,
                     "requires": {
                         "strip-bom": "^3.0.0"
+                    }
+                },
+                "end-of-stream": {
+                    "version": "1.4.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "once": "^1.4.0"
                     }
                 },
                 "error-ex": {
@@ -1567,12 +1540,12 @@
                     "dev": true
                 },
                 "execa": {
-                    "version": "0.7.0",
+                    "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "cross-spawn": "^5.0.1",
-                        "get-stream": "^3.0.0",
+                        "cross-spawn": "^6.0.0",
+                        "get-stream": "^4.0.0",
                         "is-stream": "^1.1.0",
                         "npm-run-path": "^2.0.0",
                         "p-finally": "^1.0.0",
@@ -1581,11 +1554,13 @@
                     },
                     "dependencies": {
                         "cross-spawn": {
-                            "version": "5.1.0",
+                            "version": "6.0.5",
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "lru-cache": "^4.0.1",
+                                "nice-try": "^1.0.4",
+                                "path-key": "^2.0.1",
+                                "semver": "^5.5.0",
                                 "shebang-command": "^1.2.0",
                                 "which": "^1.2.9"
                             }
@@ -1630,9 +1605,12 @@
                     "dev": true
                 },
                 "get-stream": {
-                    "version": "3.0.0",
+                    "version": "4.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
                 },
                 "glob": {
                     "version": "7.1.3",
@@ -1648,28 +1626,25 @@
                     }
                 },
                 "graceful-fs": {
-                    "version": "4.1.11",
+                    "version": "4.1.15",
                     "bundled": true,
                     "dev": true
                 },
                 "handlebars": {
-                    "version": "4.0.11",
+                    "version": "4.1.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "async": "^1.4.0",
+                        "async": "^2.5.0",
                         "optimist": "^0.6.1",
-                        "source-map": "^0.4.4",
-                        "uglify-js": "^2.6"
+                        "source-map": "^0.6.1",
+                        "uglify-js": "^3.1.4"
                     },
                     "dependencies": {
                         "source-map": {
-                            "version": "0.4.4",
+                            "version": "0.6.1",
                             "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "amdefine": ">=0.0.4"
-                            }
+                            "dev": true
                         }
                     }
                 },
@@ -1677,6 +1652,14 @@
                     "version": "3.0.0",
                     "bundled": true,
                     "dev": true
+                },
+                "hasha": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "is-stream": "^1.0.1"
+                    }
                 },
                 "hosted-git-info": {
                     "version": "2.7.1",
@@ -1703,7 +1686,7 @@
                     "dev": true
                 },
                 "invert-kv": {
-                    "version": "1.0.0",
+                    "version": "2.0.0",
                     "bundled": true,
                     "dev": true
                 },
@@ -1711,19 +1694,6 @@
                     "version": "0.2.1",
                     "bundled": true,
                     "dev": true
-                },
-                "is-buffer": {
-                    "version": "1.1.6",
-                    "bundled": true,
-                    "dev": true
-                },
-                "is-builtin-module": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "builtin-modules": "^1.0.0"
-                    }
                 },
                 "is-fullwidth-code-point": {
                     "version": "2.0.0",
@@ -1741,12 +1711,12 @@
                     "dev": true
                 },
                 "istanbul-lib-coverage": {
-                    "version": "2.0.1",
+                    "version": "2.0.3",
                     "bundled": true,
                     "dev": true
                 },
                 "istanbul-lib-hook": {
-                    "version": "2.0.1",
+                    "version": "2.0.3",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -1754,22 +1724,32 @@
                     }
                 },
                 "istanbul-lib-report": {
-                    "version": "2.0.2",
+                    "version": "2.0.4",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "istanbul-lib-coverage": "^2.0.1",
+                        "istanbul-lib-coverage": "^2.0.3",
                         "make-dir": "^1.3.0",
-                        "supports-color": "^5.4.0"
+                        "supports-color": "^6.0.0"
+                    },
+                    "dependencies": {
+                        "supports-color": {
+                            "version": "6.1.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "has-flag": "^3.0.0"
+                            }
+                        }
                     }
                 },
                 "istanbul-lib-source-maps": {
-                    "version": "2.0.1",
+                    "version": "3.0.2",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "debug": "^3.1.0",
-                        "istanbul-lib-coverage": "^2.0.1",
+                        "debug": "^4.1.1",
+                        "istanbul-lib-coverage": "^2.0.3",
                         "make-dir": "^1.3.0",
                         "rimraf": "^2.6.2",
                         "source-map": "^0.6.1"
@@ -1783,11 +1763,11 @@
                     }
                 },
                 "istanbul-reports": {
-                    "version": "2.0.1",
+                    "version": "2.1.1",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "handlebars": "^4.0.11"
+                        "handlebars": "^4.1.0"
                     }
                 },
                 "json-parse-better-errors": {
@@ -1795,26 +1775,12 @@
                     "bundled": true,
                     "dev": true
                 },
-                "kind-of": {
-                    "version": "3.2.2",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                },
-                "lazy-cache": {
-                    "version": "1.0.4",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
                 "lcid": {
-                    "version": "1.0.0",
+                    "version": "2.0.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "invert-kv": "^1.0.0"
+                        "invert-kv": "^2.0.0"
                     }
                 },
                 "load-json-file": {
@@ -1837,18 +1803,18 @@
                         "path-exists": "^3.0.0"
                     }
                 },
+                "lodash": {
+                    "version": "4.17.11",
+                    "bundled": true,
+                    "dev": true
+                },
                 "lodash.flattendeep": {
                     "version": "4.4.0",
                     "bundled": true,
                     "dev": true
                 },
-                "longest": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "dev": true
-                },
                 "lru-cache": {
-                    "version": "4.1.3",
+                    "version": "4.1.5",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -1864,25 +1830,22 @@
                         "pify": "^3.0.0"
                     }
                 },
-                "md5-hex": {
-                    "version": "2.0.0",
+                "map-age-cleaner": {
+                    "version": "0.1.3",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "md5-o-matic": "^0.1.1"
+                        "p-defer": "^1.0.0"
                     }
                 },
-                "md5-o-matic": {
-                    "version": "0.1.1",
-                    "bundled": true,
-                    "dev": true
-                },
                 "mem": {
-                    "version": "1.1.0",
+                    "version": "4.1.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "mimic-fn": "^1.0.0"
+                        "map-age-cleaner": "^0.1.1",
+                        "mimic-fn": "^1.0.0",
+                        "p-is-promise": "^2.0.0"
                     }
                 },
                 "merge-source-map": {
@@ -1934,17 +1897,22 @@
                     }
                 },
                 "ms": {
-                    "version": "2.0.0",
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "nice-try": {
+                    "version": "1.0.5",
                     "bundled": true,
                     "dev": true
                 },
                 "normalize-package-data": {
-                    "version": "2.4.0",
+                    "version": "2.5.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
                         "hosted-git-info": "^2.1.4",
-                        "is-builtin-module": "^1.0.0",
+                        "resolve": "^1.10.0",
                         "semver": "2 || 3 || 4 || 5",
                         "validate-npm-package-license": "^3.0.1"
                     }
@@ -1985,22 +1953,32 @@
                     "dev": true
                 },
                 "os-locale": {
-                    "version": "2.1.0",
+                    "version": "3.1.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "execa": "^0.7.0",
-                        "lcid": "^1.0.0",
-                        "mem": "^1.1.0"
+                        "execa": "^1.0.0",
+                        "lcid": "^2.0.0",
+                        "mem": "^4.0.0"
                     }
+                },
+                "p-defer": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
                 },
                 "p-finally": {
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true
                 },
-                "p-limit": {
+                "p-is-promise": {
                     "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "p-limit": {
+                    "version": "2.1.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -2021,13 +1999,13 @@
                     "dev": true
                 },
                 "package-hash": {
-                    "version": "2.0.0",
+                    "version": "3.0.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.11",
+                        "graceful-fs": "^4.1.15",
+                        "hasha": "^3.0.0",
                         "lodash.flattendeep": "^4.4.0",
-                        "md5-hex": "^2.0.0",
                         "release-zalgo": "^1.0.0"
                     }
                 },
@@ -2052,6 +2030,11 @@
                 },
                 "path-key": {
                     "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "path-parse": {
+                    "version": "1.0.6",
                     "bundled": true,
                     "dev": true
                 },
@@ -2081,6 +2064,15 @@
                     "bundled": true,
                     "dev": true
                 },
+                "pump": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "end-of-stream": "^1.1.0",
+                        "once": "^1.3.1"
+                    }
+                },
                 "read-pkg": {
                     "version": "3.0.0",
                     "bundled": true,
@@ -2108,11 +2100,6 @@
                         "es6-error": "^4.0.1"
                     }
                 },
-                "repeat-string": {
-                    "version": "1.6.1",
-                    "bundled": true,
-                    "dev": true
-                },
                 "require-directory": {
                     "version": "2.1.1",
                     "bundled": true,
@@ -2123,26 +2110,25 @@
                     "bundled": true,
                     "dev": true
                 },
+                "resolve": {
+                    "version": "1.10.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "path-parse": "^1.0.6"
+                    }
+                },
                 "resolve-from": {
                     "version": "4.0.0",
                     "bundled": true,
                     "dev": true
                 },
-                "right-align": {
-                    "version": "0.1.3",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "align-text": "^0.1.1"
-                    }
-                },
                 "rimraf": {
-                    "version": "2.6.2",
+                    "version": "2.6.3",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "glob": "^7.0.5"
+                        "glob": "^7.1.3"
                     }
                 },
                 "safe-buffer": {
@@ -2151,7 +2137,7 @@
                     "dev": true
                 },
                 "semver": {
-                    "version": "5.5.0",
+                    "version": "5.6.0",
                     "bundled": true,
                     "dev": true
                 },
@@ -2178,12 +2164,6 @@
                     "bundled": true,
                     "dev": true
                 },
-                "source-map": {
-                    "version": "0.5.7",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
                 "spawn-wrap": {
                     "version": "1.4.2",
                     "bundled": true,
@@ -2198,7 +2178,7 @@
                     }
                 },
                 "spdx-correct": {
-                    "version": "3.0.0",
+                    "version": "3.1.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -2207,7 +2187,7 @@
                     }
                 },
                 "spdx-exceptions": {
-                    "version": "2.1.0",
+                    "version": "2.2.0",
                     "bundled": true,
                     "dev": true
                 },
@@ -2221,7 +2201,7 @@
                     }
                 },
                 "spdx-license-ids": {
-                    "version": "3.0.0",
+                    "version": "3.0.3",
                     "bundled": true,
                     "dev": true
                 },
@@ -2252,16 +2232,8 @@
                     "bundled": true,
                     "dev": true
                 },
-                "supports-color": {
-                    "version": "5.4.0",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                },
                 "test-exclude": {
-                    "version": "5.0.0",
+                    "version": "5.1.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -2272,35 +2244,22 @@
                     }
                 },
                 "uglify-js": {
-                    "version": "2.8.29",
+                    "version": "3.4.9",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "source-map": "~0.5.1",
-                        "uglify-to-browserify": "~1.0.0",
-                        "yargs": "~3.10.0"
+                        "commander": "~2.17.1",
+                        "source-map": "~0.6.1"
                     },
                     "dependencies": {
-                        "yargs": {
-                            "version": "3.10.0",
+                        "source-map": {
+                            "version": "0.6.1",
                             "bundled": true,
                             "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "camelcase": "^1.0.2",
-                                "cliui": "^2.1.0",
-                                "decamelize": "^1.0.0",
-                                "window-size": "0.1.0"
-                            }
+                            "optional": true
                         }
                     }
-                },
-                "uglify-to-browserify": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
                 },
                 "uuid": {
                     "version": "3.3.2",
@@ -2308,7 +2267,7 @@
                     "dev": true
                 },
                 "validate-npm-package-license": {
-                    "version": "3.0.3",
+                    "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -2328,12 +2287,6 @@
                     "version": "2.0.0",
                     "bundled": true,
                     "dev": true
-                },
-                "window-size": {
-                    "version": "0.1.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
                 },
                 "wordwrap": {
                     "version": "0.0.3",
@@ -2388,7 +2341,7 @@
                     "dev": true
                 },
                 "write-file-atomic": {
-                    "version": "2.3.0",
+                    "version": "2.4.2",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -2398,7 +2351,7 @@
                     }
                 },
                 "y18n": {
-                    "version": "3.2.1",
+                    "version": "4.0.0",
                     "bundled": true,
                     "dev": true
                 },
@@ -2408,87 +2361,31 @@
                     "dev": true
                 },
                 "yargs": {
-                    "version": "11.1.0",
+                    "version": "12.0.5",
                     "bundled": true,
                     "dev": true,
                     "requires": {
                         "cliui": "^4.0.0",
-                        "decamelize": "^1.1.1",
-                        "find-up": "^2.1.0",
+                        "decamelize": "^1.2.0",
+                        "find-up": "^3.0.0",
                         "get-caller-file": "^1.0.1",
-                        "os-locale": "^2.0.0",
+                        "os-locale": "^3.0.0",
                         "require-directory": "^2.1.1",
                         "require-main-filename": "^1.0.1",
                         "set-blocking": "^2.0.0",
                         "string-width": "^2.0.0",
                         "which-module": "^2.0.0",
-                        "y18n": "^3.2.1",
-                        "yargs-parser": "^9.0.2"
-                    },
-                    "dependencies": {
-                        "cliui": {
-                            "version": "4.1.0",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "string-width": "^2.1.1",
-                                "strip-ansi": "^4.0.0",
-                                "wrap-ansi": "^2.0.0"
-                            }
-                        },
-                        "find-up": {
-                            "version": "2.1.0",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "locate-path": "^2.0.0"
-                            }
-                        },
-                        "locate-path": {
-                            "version": "2.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "p-locate": "^2.0.0",
-                                "path-exists": "^3.0.0"
-                            }
-                        },
-                        "p-limit": {
-                            "version": "1.3.0",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "p-try": "^1.0.0"
-                            }
-                        },
-                        "p-locate": {
-                            "version": "2.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "p-limit": "^1.1.0"
-                            }
-                        },
-                        "p-try": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true
-                        }
+                        "y18n": "^3.2.1 || ^4.0.0",
+                        "yargs-parser": "^11.1.1"
                     }
                 },
                 "yargs-parser": {
-                    "version": "9.0.2",
+                    "version": "11.1.1",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "camelcase": "^4.1.0"
-                    },
-                    "dependencies": {
-                        "camelcase": {
-                            "version": "4.1.0",
-                            "bundled": true,
-                            "dev": true
-                        }
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
                     }
                 }
             }
@@ -2562,6 +2459,12 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+        },
+        "path-parse": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+            "dev": true
         },
         "path-type": {
             "version": "1.1.0",
@@ -2728,10 +2631,13 @@
             }
         },
         "resolve": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-            "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-            "dev": true
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+            "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+            "dev": true,
+            "requires": {
+                "path-parse": "^1.0.6"
+            }
         },
         "rimraf": {
             "version": "2.6.3",
@@ -2779,9 +2685,9 @@
             "dev": true
         },
         "source-map-support": {
-            "version": "0.5.10",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
-            "integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
+            "version": "0.5.11",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.11.tgz",
+            "integrity": "sha512-//sajEx/fGL3iw6fltKMdPvy8kL3kJ2O3iuYlRoT3k9Kb4BjOoZ+BZzaNHeuaruSt+Kf3Zk9tnfAQg9/AJqUVQ==",
             "dev": true,
             "requires": {
                 "buffer-from": "^1.0.0",
@@ -2906,9 +2812,9 @@
             }
         },
         "tap": {
-            "version": "12.5.1",
-            "resolved": "https://registry.npmjs.org/tap/-/tap-12.5.1.tgz",
-            "integrity": "sha512-FiZtRwt169oq0pmaZwC4Bw/leqdzmG7paqKA0PYk7+yGq2m3q35U9yh9Hh8x/Z+iue8V2/cFwS8x9mSZnM51cQ==",
+            "version": "12.6.0",
+            "resolved": "https://registry.npmjs.org/tap/-/tap-12.6.0.tgz",
+            "integrity": "sha512-HsU8Djx7WhkP8SZbtdtb1P/g74QdMYgLtge9/MiNZ2uKXa1KV36nHgWIFI0BlrhnzcS9n3WfqmLY2tIBTjl+ew==",
             "dev": true,
             "requires": {
                 "bind-obj-methods": "^2.0.0",
@@ -2918,7 +2824,7 @@
                 "color-support": "^1.1.0",
                 "coveralls": "^3.0.2",
                 "domain-browser": "^1.2.0",
-                "esm": "^3.1.4",
+                "esm": "^3.2.5",
                 "foreground-child": "^1.3.3",
                 "fs-exists-cached": "^1.0.0",
                 "function-loop": "^1.0.1",
@@ -2927,7 +2833,7 @@
                 "js-yaml": "^3.12.1",
                 "minipass": "^2.3.5",
                 "mkdirp": "^0.5.1",
-                "nyc": "^13.1.0",
+                "nyc": "^13.3.0",
                 "opener": "^1.5.1",
                 "os-homedir": "^1.0.2",
                 "own-or": "^1.0.0",
@@ -2936,14 +2842,14 @@
                 "signal-exit": "^3.0.0",
                 "source-map-support": "^0.5.10",
                 "stack-utils": "^1.0.2",
-                "tap-mocha-reporter": "^3.0.7",
+                "tap-mocha-reporter": "^3.0.9",
                 "tap-parser": "^7.0.0",
                 "tmatch": "^4.0.0",
                 "trivial-deferred": "^1.0.1",
-                "ts-node": "^8.0.1",
+                "ts-node": "^8.0.2",
                 "tsame": "^2.0.1",
-                "typescript": "^3.2.4",
-                "write-file-atomic": "^2.3.0",
+                "typescript": "^3.3.3",
+                "write-file-atomic": "^2.4.2",
                 "yapool": "^1.0.0"
             },
             "dependencies": {
@@ -2954,9 +2860,9 @@
                     "dev": true
                 },
                 "js-yaml": {
-                    "version": "3.12.1",
-                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
-                    "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+                    "version": "3.12.2",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
+                    "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
                     "dev": true,
                     "requires": {
                         "argparse": "^1.0.7",
@@ -2966,9 +2872,9 @@
             }
         },
         "tap-mocha-reporter": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-3.0.7.tgz",
-            "integrity": "sha512-GHVXJ38C3oPRpM3YUc43JlGdpVZYiKeT1fmAd3HH2+J+ZWwsNAUFvRRdoGsXLw9+gU9o+zXpBqhS/oXyRQYwlA==",
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-3.0.9.tgz",
+            "integrity": "sha512-VO07vhC9EG27EZdOe7bWBj1ldbK+DL9TnRadOgdQmiQOVZjFpUEQuuqO7+rNSO2kfmkq5hWeluYXDWNG/ytXTQ==",
             "dev": true,
             "requires": {
                 "color-support": "^1.1.0",
@@ -3103,9 +3009,9 @@
             "dev": true
         },
         "ts-node": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.0.2.tgz",
-            "integrity": "sha512-MosTrinKmaAcWgO8tqMjMJB22h+sp3Rd1i4fdoWY4mhBDekOwIAKI/bzmRi7IcbCmjquccYg2gcF6NBkLgr0Tw==",
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.0.3.tgz",
+            "integrity": "sha512-2qayBA4vdtVRuDo11DEFSsD/SFsBXQBRZZhbRGSIkmYmVkWjULn/GGMdG10KVqkaGndljfaTD8dKjWgcejO8YA==",
             "dev": true,
             "requires": {
                 "arg": "^4.1.0",
@@ -3145,9 +3051,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.1.tgz",
-            "integrity": "sha512-cTmIDFW7O0IHbn1DPYjkiebHxwtCMU+eTy30ZtJNBPF9j2O1ITu5XH2YnBeVRKWHqF+3JQwWJv0Q0aUgX8W7IA==",
+            "version": "3.3.3333",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3333.tgz",
+            "integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==",
             "dev": true
         },
         "underscore.string": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     ],
     "dependencies": {
         "glob": "^7.1.3",
-        "q": "~2.0"
+        "q": "~2.0",
+        "follow-redirects": "1.7.0"
     }
 }


### PR DESCRIPTION
That way the download doesn't fail when oss.sonatype.org redirects the request (fixes #12).

How I tested my changes:
I verified that the download was no longer failing after this change and I also run the `test` script. 