### PR TITLE
fail fast: refuse to start server with invalid option systemProperties

### DIFF
--- a/test/node/failure/mock_server_failure_test.js
+++ b/test/node/failure/mock_server_failure_test.js
@@ -38,6 +38,25 @@
                             test.done();
                         }
                     );
+            },
+            'if deprecated option "systemProperties" is given': function (test) {
+
+                test.expect(1);
+                mockserver
+                    .start_mockserver({
+                        serverPort: 1080,
+                        systemProperties: '--foo'
+                    })
+                    .then(
+                        function () {
+                            test.ok(false, "should fail to start");
+                            test.done();
+                        },
+                        function (error) {
+                            test.equal(error, 'The option "systemProperties" was renamed to "jvmOptions" in 5.4.1. Please migrate to the new option name');
+                            test.done();
+                        }
+                    );
             }
         })
     };

--- a/test/node/failure/mock_server_failure_test.js
+++ b/test/node/failure/mock_server_failure_test.js
@@ -21,7 +21,7 @@
                             test.equal(error, 'Please specify "serverPort", for example: "start_mockserver({ serverPort: 1080 })"');
                             test.done();
                         }
-                    )
+                    );
             },
             'should fail start if ports missing': function (test) {
 
@@ -37,7 +37,7 @@
                             test.equal(error, 'Please specify "serverPort", for example: "start_mockserver({ serverPort: 1080 })"');
                             test.done();
                         }
-                    )
+                    );
             },
             'should fail stop if configuration missing': function (test) {
 
@@ -53,7 +53,7 @@
                             test.equal(error, 'Please specify "serverPort", for example: "stop_mockserver({ serverPort: 1080 })"');
                             test.done();
                         }
-                    )
+                    );
             },
             'should fail stop if ports missing': function (test) {
 
@@ -69,7 +69,7 @@
                             test.equal(error, 'Please specify "serverPort", for example: "stop_mockserver({ serverPort: 1080 })"');
                             test.done();
                         }
-                    )
+                    );
             }
         })
     };

--- a/test/node/failure/mock_server_failure_test.js
+++ b/test/node/failure/mock_server_failure_test.js
@@ -26,8 +26,9 @@
             'if port is missing': function (test) {
 
                 test.expect(1);
+                var options = {};
                 mockserver
-                    .start_mockserver({})
+                    .start_mockserver(options)
                     .then(
                         function () {
                             test.ok(false, "should fail to start");
@@ -63,14 +64,14 @@
 
     exports.mock_server_stop_failure = {
         'mock server fails to stop': testCase({
-            'if configuration missing': function (test) {
+            'if configuration is missing': function (test) {
 
                 test.expect(1);
                 mockserver
                     .stop_mockserver()
                     .then(
                         function () {
-                            test.ok(false, "should fail to start");
+                            test.ok(false, "should fail to stop");
                             test.done();
                         },
                         function (error) {
@@ -82,11 +83,13 @@
             'if port is missing': function (test) {
 
                 test.expect(1);
+                var options = {};
+
                 mockserver
-                    .stop_mockserver({})
+                    .stop_mockserver(options)
                     .then(
                         function () {
-                            test.ok(false, "should fail to start");
+                            test.ok(false, "should fail to stop");
                             test.done();
                         },
                         function (error) {

--- a/test/node/failure/mock_server_failure_test.js
+++ b/test/node/failure/mock_server_failure_test.js
@@ -5,9 +5,9 @@
     var testCase = require('nodeunit').testCase;
     var mockserver = require(__dirname + '/../../..');
 
-    exports.mock_server_failure = {
+    exports.mock_server_start_failure = {
         'mock server fails to start': testCase({
-            'should fail start if configuration missing': function (test) {
+            'if configuration missing': function (test) {
 
                 test.expect(1);
                 mockserver
@@ -23,7 +23,7 @@
                         }
                     );
             },
-            'should fail start if ports missing': function (test) {
+            'if port is missing': function (test) {
 
                 test.expect(1);
                 mockserver
@@ -38,8 +38,13 @@
                             test.done();
                         }
                     );
-            },
-            'should fail stop if configuration missing': function (test) {
+            }
+        })
+    };
+
+    exports.mock_server_stop_failure = {
+        'mock server fails to stop': testCase({
+            'if configuration missing': function (test) {
 
                 test.expect(1);
                 mockserver
@@ -55,7 +60,7 @@
                         }
                     );
             },
-            'should fail stop if ports missing': function (test) {
+            'if port is missing': function (test) {
 
                 test.expect(1);
                 mockserver

--- a/test/node/started/mock_server_started_test.js
+++ b/test/node/started/mock_server_started_test.js
@@ -8,7 +8,7 @@
 
     exports.mock_server_started = {
         'mock server should have started': testCase({
-            'should allows expectation to be setup': function (test) {
+            'should allow expectation to be set up': function (test) {
                 var port = 1081;
 
                 test.expect(2);


### PR DESCRIPTION
This PR fixes some jshint warnings, restructures one test a bit and finally checks if systemProperties is used.
If so, honoring the fail fast philosophy, the server refuses to start and prints an error regarding the renamed option.